### PR TITLE
Update package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/alinemorelli/react-gtm"
+    "url": "https://github.com/mineko-io/react-gtm"
   },
   "author": {
     "name": "Aline Morelli",
-    "email": "aline.morelliw@gmail.com",
-    "url": "https://github.com/alinemorelli"
+    "email": "aline.morelliw@gmail.com"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/alinemorelli/react-gtm/issues"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
**WHY**

Links from @mineko-io/react-gtm in npmjs.com wrongly point to the alinemorelli/react-gtm repository and causes confusion.

This updates some of that metadata to remedy that confusion and correct the links. 